### PR TITLE
Update metadata fields in canopy.yml

### DIFF
--- a/canopy.yml
+++ b/canopy.yml
@@ -9,11 +9,9 @@ manifest:
   # https://iiif.vam.ac.uk/collections/O136839/manifest.json
   # https://iiif.vam.ac.uk/collections/O74660/manifest.json
 metadata:
-  - Summary
   - Themes
+  - Key People and Groups
   - Main Location
-  - Key People
-  - Historical Context
   - Completed
   - Year
   - Bureau


### PR DESCRIPTION
Removed 'Summary' and 'Key People' from metadata, renamed 'Key People' as 'Key People and Groups'. This will make it so the Filters work on Search page and the Related Items show under each item on works pages.

<img width="1536" height="1256" alt="image" src="https://github.com/user-attachments/assets/9460f016-6d32-4181-8632-925be29e5cbf" />

<img width="1536" height="1256" alt="image" src="https://github.com/user-attachments/assets/145f1eca-6e20-4fd4-9e2e-e295ec6d8fc6" />
